### PR TITLE
fix inconsistent function name

### DIFF
--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -51,7 +51,7 @@ pub fn get() -> Result<String> {
 }
 
 /// Sets the wallpaper for the current desktop from a file path.
-pub fn set_from_file(path: &str) -> Result<()> {
+pub fn set_from_path(path: &str) -> Result<()> {
     let desktop = env::var("XDG_CURRENT_DESKTOP")?;
 
     if is_gnome_compliant(&desktop) {

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -51,7 +51,7 @@ pub fn get() -> Result<String> {
 }
 
 /// Sets the wallpaper for the current desktop from a file path.
-pub fn set_from_path(path: &str) -> Result<()> {
+pub fn set_from_file(path: &str) -> Result<()> {
     let desktop = env::var("XDG_CURRENT_DESKTOP")?;
 
     if is_gnome_compliant(&desktop) {

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -16,7 +16,7 @@ pub fn get() -> Result<String> {
 }
 
 // Sets the wallpaper from a file.
-pub fn set_from_file(path: &str) -> Result<()> {
+pub fn set_from_path(path: &str) -> Result<()> {
     run(
         "osascript",
         &[
@@ -32,5 +32,5 @@ pub fn set_from_file(path: &str) -> Result<()> {
 // Sets the wallpaper from a URL.
 pub fn set_from_url(url: &str) -> Result<()> {
     let path = download_image(&url.parse()?)?;
-    set_from_file(&path)
+    set_from_path(&path)
 }

--- a/src/unsupported.rs
+++ b/src/unsupported.rs
@@ -4,7 +4,7 @@ pub fn get() -> Result<String> {
     Err("unsupported operating system".into())
 }
 
-pub fn set_from_file(_: &str) -> Result<()> {
+pub fn set_from_path(_: &str) -> Result<()> {
     Err("unsupported operating system".into())
 }
 

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -36,7 +36,7 @@ pub fn get() -> Result<String> {
 }
 
 /// Sets the wallpaper from a file.
-pub fn set_from_file(path: &str) -> Result<()> {
+pub fn set_from_path(path: &str) -> Result<()> {
     unsafe {
         let path = OsStr::new(path)
             .encode_wide()
@@ -61,5 +61,5 @@ pub fn set_from_file(path: &str) -> Result<()> {
 /// Sets the wallpaper from a URL.
 pub fn set_from_url(url: &str) -> Result<()> {
     let path = download_image(&url.parse()?)?;
-    set_from_file(&path)
+    set_from_path(&path)
 }


### PR DESCRIPTION
For every platform, the function for setting the wallpaper from a file path is `set_from_file` - except for linux.
This fix does break backwards compatibility.