### PR TITLE
update reqwest dependency to 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "Unlicense"
 
 [target.'cfg(any(unix, windows))'.dependencies]
 dirs = "1.0"
-reqwest = "0.8"
+reqwest = "0.9"
 url = "1.7"
 
 [target.'cfg(unix)'.dependencies]


### PR DESCRIPTION
Build fails saying that it was "Unable to detect OpenSSL version" (problem adressed at rust-lang/rustup.rs#1518) due to incompability to `openssl v1.1.1`.

Updating `reqwest` to version 0.9 solves it.