### PR TITLE
Adress issue #5 : many unused dependencies pulled in

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,21 +8,22 @@ readme = "readme.md"
 keywords = ["desktop", "wallpaper", "background"]
 categories = ["api-bindings"]
 license = "Unlicense"
+edition = "2018"
 
 [features]
-default = ["from-url"]
-from-url = ["reqwest", "url"]
+default = ["from_url"]
+from_url = ["reqwest", "url"]
 
 [target.'cfg(any(unix, windows))'.dependencies]
-dirs = "1.0"
-reqwest = { version = "0.9", optional = true }
-url = { version = "1.7", optional = true }
+dirs = "3.0.1"
+reqwest = { version = "0.10.8", optional = true, features = ["blocking"] }
+url = { version = "2.1.1", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 enquote = "1"
 
 [target.'cfg(all(unix, not(target_os = "macos")))'.dependencies]
-rust-ini = "0.12"
+rust-ini = "0.15.3"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["winuser"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,12 @@ license = "Unlicense"
 
 [features]
 default = ["from-url"]
-from-url = ["reqwest"]
+from-url = ["reqwest", "url"]
 
 [target.'cfg(any(unix, windows))'.dependencies]
 dirs = "1.0"
 reqwest = { version = "0.9", optional = true }
-url = "1.7"
+url = { version = "1.7", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 enquote = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,13 @@ keywords = ["desktop", "wallpaper", "background"]
 categories = ["api-bindings"]
 license = "Unlicense"
 
+[features]
+default = ["from-url"]
+from-url = ["reqwest"]
+
 [target.'cfg(any(unix, windows))'.dependencies]
 dirs = "1.0"
-reqwest = "0.9"
+reqwest = { version = "0.9", optional = true }
 url = "1.7"
 
 [target.'cfg(unix)'.dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@ mod unsupported;
 #[cfg(not(any(unix, windows)))]
 pub use unsupported::*;
 
-type Result<T> = std::result::Result<T, Box<Error>>;
+type Result<T> = std::result::Result<T, Box<dyn Error>>;
 
 #[cfg(all(any(unix, windows), feature = "from-url"))]
 fn download_image(url: &Url) -> Result<String> {
@@ -110,7 +110,8 @@ fn get_stdout(command: &str, args: &[&str]) -> Result<String> {
             "{} exited with status code {}",
             command,
             output.status.code().unwrap_or(-1),
-        ).into())
+        )
+        .into())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,14 +32,12 @@ use std::error::Error;
 // common
 #[cfg(any(unix, windows))]
 extern crate dirs;
-#[cfg(all(any(unix, windows), feature = "from-url"))]
+#[cfg(all(any(unix, windows), feature = "from_url"))]
 extern crate reqwest;
-#[cfg(all(any(unix, windows), feature = "from-url"))]
+#[cfg(all(any(unix, windows), feature = "from_url"))]
 extern crate url;
 
-#[cfg(all(any(unix, windows), feature = "from-url"))]
-use std::fs::File;
-#[cfg(all(any(unix, windows), feature = "from-url"))]
+#[cfg(all(any(unix, windows), feature = "from_url"))]
 use url::Url;
 
 // unix
@@ -82,8 +80,8 @@ pub use unsupported::*;
 
 type Result<T> = std::result::Result<T, Box<dyn Error>>;
 
-#[cfg(all(any(unix, windows), feature = "from-url"))]
-fn download_image(url: &Url) -> Result<String> {
+#[cfg(all(any(unix, windows), feature = "from_url"))]
+async fn download_image(url: &Url) -> Result<String> {
     let cache_dir = dirs::cache_dir().ok_or("no cache dir")?;
     let segments = url.path_segments().ok_or("no path segments")?;
     let mut file_name = segments.last().ok_or("no file name")?;
@@ -92,8 +90,8 @@ fn download_image(url: &Url) -> Result<String> {
     }
     let file_path = cache_dir.join(file_name);
 
-    let mut file = File::create(&file_path)?;
-    reqwest::get(url.as_str())?.copy_to(&mut file)?;
+    // let mut file = File::create(&file_path)?;
+    std::fs::write(&file_path, reqwest::get(url.as_str()).await?.bytes().await?)?; //.copy_to(&mut file)?;
 
     Ok(file_path.to_str().to_owned().unwrap().into())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,14 +32,14 @@ use std::error::Error;
 // common
 #[cfg(any(unix, windows))]
 extern crate dirs;
-#[cfg(any(unix, windows))]
+#[cfg(all(any(unix, windows), feature = "from-url"))]
 extern crate reqwest;
-#[cfg(any(unix, windows))]
+#[cfg(all(any(unix, windows), feature = "from-url"))]
 extern crate url;
 
-#[cfg(any(unix, windows))]
+#[cfg(all(any(unix, windows), feature = "from-url"))]
 use std::fs::File;
-#[cfg(any(unix, windows))]
+#[cfg(all(any(unix, windows), feature = "from-url"))]
 use url::Url;
 
 // unix
@@ -82,7 +82,7 @@ pub use unsupported::*;
 
 type Result<T> = std::result::Result<T, Box<Error>>;
 
-#[cfg(any(unix, windows))]
+#[cfg(all(any(unix, windows), feature = "from-url"))]
 fn download_image(url: &Url) -> Result<String> {
     let cache_dir = dirs::cache_dir().ok_or("no cache dir")?;
     let segments = url.path_segments().ok_or("no path segments")?;

--- a/src/linux/kde.rs
+++ b/src/linux/kde.rs
@@ -1,13 +1,13 @@
+use crate::run;
 use dirs;
 use enquote;
-use run;
 use std::fs::File;
 use std::io::BufRead;
 use std::io::BufReader;
 use Result;
 
 /// Returns the wallpaper of KDE.
-pub fn get() -> Result<String> {
+pub fn get() -> Result<String, Box<dyn std::error::Error>> {
     let path = dirs::config_dir()
         .ok_or("could not find config directory")?
         .join("plasma-org.kde.plasma.desktop-appletsrc");
@@ -28,7 +28,7 @@ pub fn get() -> Result<String> {
 }
 
 /// Sets the wallpaper for KDE.
-pub fn set(path: &str) -> Result<()> {
+pub fn set(path: &str) -> Result<(), Box<dyn std::error::Error>> {
     run(
         "qdbus",
         &[

--- a/src/linux/lxde.rs
+++ b/src/linux/lxde.rs
@@ -3,7 +3,7 @@ use ini::Ini;
 use std::env;
 use Result;
 
-pub fn get() -> Result<String> {
+pub fn get() -> Result<String, Box<dyn std::error::Error>> {
     let session = env::var("DESKTOP_SESSION").unwrap_or_else(|_| "LXDE".into());
     let path = dirs::config_dir()
         .ok_or("could not find config directory")?
@@ -14,5 +14,6 @@ pub fn get() -> Result<String> {
         .ok_or("no '*' section found")?
         .get("wallpaper")
         .ok_or("no lxde image found")?
-        .clone())
+        .clone()
+        .to_string())
 }

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -1,6 +1,7 @@
 mod kde;
 mod lxde;
 
+#[cfg(feature = "from-url")]
 use download_image;
 use enquote;
 use get_stdout;
@@ -106,6 +107,7 @@ pub fn set_from_path(path: &str) -> Result<()> {
 }
 
 /// Sets the wallpaper for the current desktop from a URL.
+#[cfg(feature = "from-url")]
 pub fn set_from_url(url: &str) -> Result<()> {
     let desktop = env::var("XDG_CURRENT_DESKTOP")?;
 

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -1,16 +1,16 @@
 mod kde;
 mod lxde;
 
-#[cfg(feature = "from-url")]
-use download_image;
+#[cfg(feature = "from_url")]
+use crate::download_image;
+use crate::get_stdout;
+use crate::run;
 use enquote;
-use get_stdout;
-use run;
 use std::env;
 use Result;
 
 /// Returns the wallpaper of the current desktop.
-pub fn get() -> Result<String> {
+pub fn get() -> Result<String, Box<dyn std::error::Error>> {
     let desktop = env::var("XDG_CURRENT_DESKTOP")?;
 
     if is_gnome_compliant(&desktop) {
@@ -52,7 +52,7 @@ pub fn get() -> Result<String> {
 }
 
 /// Sets the wallpaper for the current desktop from a file path.
-pub fn set_from_path(path: &str) -> Result<()> {
+pub fn set_from_path(path: &str) -> Result<(), Box<dyn std::error::Error>> {
     let desktop = env::var("XDG_CURRENT_DESKTOP")?;
 
     if is_gnome_compliant(&desktop) {
@@ -107,8 +107,8 @@ pub fn set_from_path(path: &str) -> Result<()> {
 }
 
 /// Sets the wallpaper for the current desktop from a URL.
-#[cfg(feature = "from-url")]
-pub fn set_from_url(url: &str) -> Result<()> {
+#[cfg(feature = "from_url")]
+pub async fn set_from_url(url: &str) -> Result<(), Box<dyn std::error::Error>> {
     let desktop = env::var("XDG_CURRENT_DESKTOP")?;
 
     match desktop.as_str() {
@@ -122,9 +122,9 @@ pub fn set_from_url(url: &str) -> Result<()> {
                 &enquote::enquote('"', url),
             ],
         ),
-        "i3" => run("feh", &["--bg-fill", url]),
+        "i3" => run("feh", &["--bg-fill", &url.replace("\"", "")]),
         _ => {
-            let path = download_image(&url.parse()?)?;
+            let path = download_image(&url.parse()?).await?;
             set_from_path(&path)
         }
     }
@@ -135,7 +135,7 @@ fn is_gnome_compliant(desktop: &str) -> bool {
     desktop.contains("GNOME") || desktop == "Unity" || desktop == "Pantheon"
 }
 
-fn parse_dconf(command: &str, args: &[&str]) -> Result<String> {
+fn parse_dconf(command: &str, args: &[&str]) -> Result<String, Box<dyn std::error::Error>> {
     let mut stdout = enquote::unquote(&get_stdout(command, args)?)?;
     // removes file protocol
     if stdout.starts_with("file://") {

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -5,7 +5,7 @@ use run;
 use Result;
 
 /// Returns the current wallpaper.
-pub fn get() -> Result<String> {
+pub fn get() -> Result<String, Box<dyn std::error::Error>> {
     get_stdout(
         "osascript",
         &[
@@ -16,7 +16,7 @@ pub fn get() -> Result<String> {
 }
 
 // Sets the wallpaper from a file.
-pub fn set_from_path(path: &str) -> Result<()> {
+pub fn set_from_path(path: &str) -> Result<(), Box<dyn std::error::Error>> {
     run(
         "osascript",
         &[
@@ -31,7 +31,7 @@ pub fn set_from_path(path: &str) -> Result<()> {
 
 // Sets the wallpaper from a URL.
 #[cfg("from-url")]
-pub fn set_from_url(url: &str) -> Result<()> {
+pub fn set_from_url(url: &str) -> Result<(), Box<dyn std::error::Error>> {
     let path = download_image(&url.parse()?)?;
     set_from_path(&path)
 }

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -30,6 +30,7 @@ pub fn set_from_path(path: &str) -> Result<()> {
 }
 
 // Sets the wallpaper from a URL.
+#[cfg("from-url")]
 pub fn set_from_url(url: &str) -> Result<()> {
     let path = download_image(&url.parse()?)?;
     set_from_path(&path)

--- a/src/unsupported.rs
+++ b/src/unsupported.rs
@@ -8,6 +8,7 @@ pub fn set_from_path(_: &str) -> Result<()> {
     Err("unsupported operating system".into())
 }
 
+#[cfg("from-url")]
 pub fn set_from_url(_: &str) -> Result<()> {
     Err("unsupported operating system".into())
 }

--- a/src/unsupported.rs
+++ b/src/unsupported.rs
@@ -1,14 +1,14 @@
 use Result;
 
-pub fn get() -> Result<String> {
+pub fn get() -> Result<String, Box<dyn std::error::Error>> {
     Err("unsupported operating system".into())
 }
 
-pub fn set_from_path(_: &str) -> Result<()> {
+pub fn set_from_path(_: &str) -> Result<(), Box<dyn std::error::Error>> {
     Err("unsupported operating system".into())
 }
 
 #[cfg("from-url")]
-pub fn set_from_url(_: &str) -> Result<()> {
+pub fn set_from_url(_: &str) -> Result<(), Box<dyn std::error::Error>> {
     Err("unsupported operating system".into())
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,3 +1,4 @@
+#[cfg("from-url")]
 use download_image;
 use std::ffi::OsStr;
 use std::io;
@@ -59,6 +60,7 @@ pub fn set_from_path(path: &str) -> Result<()> {
 }
 
 /// Sets the wallpaper from a URL.
+#[cfg("from-url")]
 pub fn set_from_url(url: &str) -> Result<()> {
     let path = download_image(&url.parse()?)?;
     set_from_path(&path)


### PR DESCRIPTION
This is the solution I proposed in issue #5, it allows the user to opt out of compiling `reqwest` and `url` when not using the `set_from_url` functionality.

I should mention that although I am unable to verify that nothing was broken for any platform, it should be fine considering I only did very minor changes to non-attribute lines.