### PR TITLE
Fixed `use` in macos

### DIFF
--- a/src/macos.rs
+++ b/src/macos.rs
@@ -2,6 +2,7 @@ use enquote;
 use get_stdout;
 use run;
 use Result;
+use Mode;
 
 /// Returns the current wallpaper.
 pub fn get() -> Result<String> {


### PR DESCRIPTION
```
error[E0412]: cannot find type `Mode` in this scope
  --> src/macos.rs:32:20
   |
32 | pub fn set_mode(_: Mode) -> Result<()> {
   |                    ^^^^ not found in this scope
   |
help: consider importing this enum
   |
1  | use Mode;
   |

error: aborting due to previous error
```