### PR TITLE
Restored `set_from_url`, but as optional feature 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,8 @@ license = "Unlicense"
 
 [target.'cfg(any(unix, windows))'.dependencies]
 dirs = "1.0"
+reqwest = { version = "0.11", optional = true, features = ["blocking"]}
+url = { version = "2.2", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 enquote = "1"
@@ -21,3 +23,6 @@ rust-ini = "0.12"
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["winuser"] }
 winreg = "0.9"
+
+[features]
+from_url = ["reqwest", "url"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "wallpaper"
 version = "3.1.1"
+edition = "2018"
 authors = ["reujab <reujab@gmail.com>"]
 description = "Gets and sets the desktop wallpaper/background."
 repository = "https://github.com/reujab/wallpaper.rs"

--- a/readme.md
+++ b/readme.md
@@ -28,13 +28,14 @@ fn main() {
     println!("{:?}", wallpaper::get());
     // Sets the wallpaper for the current desktop from a file path.
     wallpaper::set_from_path("/usr/share/backgrounds/gnome/adwaita-day.png").unwrap();
+    // Sets the wallpaper style.
     wallpaper::set_mode(wallpaper::Mode::Crop).unwrap();
     // Returns the wallpaper of the current desktop.
     println!("{:?}", wallpaper::get());
 }
 ```
 
-Make sure you activated the `from_url` feature of the wallpaper crate on Cargo.toml:
+If you want to set an image as background via an URL, make sure you activated the `from_url` feature of the wallpaper crate on Cargo.toml:
 
 ```toml
 [dependencies]

--- a/readme.md
+++ b/readme.md
@@ -16,14 +16,30 @@ The supported desktops are:
 * Most Wayland compositors (set only, requires swaybg)
 * i3 (set only, requires feh)
 
-## Example
+## Examples
 ```rust
-extern crate wallpaper;
+use wallpaper;
 
 fn main() {
-    println!("{:?}", wallpaper::get().unwrap());
+    // Returns the wallpaper of the current desktop.
+    println!("{:?}", wallpaper::get());
+    // Sets the wallpaper for the current desktop from a file path.
     wallpaper::set_from_path("/usr/share/backgrounds/gnome/adwaita-day.png").unwrap();
+    // Returns the wallpaper of the current desktop.
+    println!("{:?}", wallpaper::get());
+}
+```
+```rust
+use wallpaper;
+
+fn main() {
+    // Returns the wallpaper of the current desktop.
+    println!("{:?}", wallpaper::get());
+    // Sets the wallpaper for the current desktop from a URL.
+    wallpaper::set_from_url("https://source.unsplash.com/random").unwrap();
+
     wallpaper::set_mode(wallpaper::Mode::Crop).unwrap();
-    println!("{:?}", wallpaper::get().unwrap());
+    // Returns the wallpaper of the current desktop.
+    println!("{:?}", wallpaper::get());
 }
 ```

--- a/readme.md
+++ b/readme.md
@@ -1,22 +1,25 @@
 # wallpaper [![crate](https://img.shields.io/crates/v/wallpaper.svg)](https://crates.io/crates/wallpaper) [![docs](https://docs.rs/wallpaper/badge.svg)](https://docs.rs/wallpaper)
+
 This Rust library gets and sets the desktop wallpaper/background.
 
 The supported desktops are:
-* Windows
-* macOS
-* GNOME
-* KDE
-* Cinnamon
-* Unity
-* Budgie
-* XFCE
-* LXDE
-* MATE
-* Deepin
-* Most Wayland compositors (set only, requires swaybg)
-* i3 (set only, requires feh)
+
+- Windows
+- macOS
+- GNOME
+- KDE
+- Cinnamon
+- Unity
+- Budgie
+- XFCE
+- LXDE
+- MATE
+- Deepin
+- Most Wayland compositors (set only, requires swaybg)
+- i3 (set only, requires feh)
 
 ## Examples
+
 ```rust
 use wallpaper;
 
@@ -25,10 +28,21 @@ fn main() {
     println!("{:?}", wallpaper::get());
     // Sets the wallpaper for the current desktop from a file path.
     wallpaper::set_from_path("/usr/share/backgrounds/gnome/adwaita-day.png").unwrap();
+    wallpaper::set_mode(wallpaper::Mode::Crop).unwrap();
     // Returns the wallpaper of the current desktop.
     println!("{:?}", wallpaper::get());
 }
 ```
+
+Make sure you activated the `from_url` feature of the wallpaper crate on Cargo.toml:
+
+```toml
+[dependencies]
+wallpaper = { version = "3", features = ["from_url"] }
+```
+
+Then, on your main.rs:
+
 ```rust
 use wallpaper;
 
@@ -37,8 +51,6 @@ fn main() {
     println!("{:?}", wallpaper::get());
     // Sets the wallpaper for the current desktop from a URL.
     wallpaper::set_from_url("https://source.unsplash.com/random").unwrap();
-
-    wallpaper::set_mode(wallpaper::Mode::Crop).unwrap();
     // Returns the wallpaper of the current desktop.
     println!("{:?}", wallpaper::get());
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@ extern crate ini;
 mod linux;
 
 #[cfg(all(unix, not(target_os = "macos")))]
-pub use linux::*;
+pub use crate::linux::*;
 
 // macos
 #[cfg(target_os = "macos")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,19 +28,6 @@
 
 use std::error::Error;
 
-// i really wish you could group multiple lines using a single #[cfg]
-
-// common
-#[cfg(any(unix, windows))]
-extern crate dirs;
-
-#[cfg(feature = "from_url")]
-#[cfg(any(unix, windows))]
-extern crate reqwest;
-
-#[cfg(feature = "from_url")]
-#[cfg(any(unix, windows))]
-extern crate url;
 
 #[cfg(feature = "from_url")]
 #[cfg(any(unix, windows))]
@@ -49,14 +36,6 @@ use std::fs::File;
 #[cfg(feature = "from_url")]
 #[cfg(any(unix, windows))]
 use url::Url;
-
-// unix
-#[cfg(unix)]
-extern crate enquote;
-
-// linux and *bsd
-#[cfg(all(unix, not(target_os = "macos")))]
-extern crate ini;
 
 #[cfg(all(unix, not(target_os = "macos")))]
 mod linux;
@@ -70,13 +49,6 @@ mod macos;
 
 #[cfg(target_os = "macos")]
 pub use macos::*;
-
-// windows
-#[cfg(windows)]
-extern crate winapi;
-
-#[cfg(windows)]
-extern crate winreg;
 
 #[cfg(windows)]
 mod windows;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,6 @@
 
 use std::error::Error;
 
-
 #[cfg(feature = "from_url")]
 #[cfg(any(unix, windows))]
 use std::fs::File;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,18 +12,19 @@
 //! * LXDE
 //! * MATE
 //! * Deepin
-//! * i3 (set only)
+//! * Most Wayland compositors (set only, requires swaybg)
+//! * i3 (set only, requires feh)
 //!
-//! # Examples
+//! # Example
 //! ```
-//! extern crate wallpaper;
+//! use wallpaper;
 //!
-//! fn main() {
-//!     println!("{:?}", wallpaper::get());
-//!     wallpaper::set_from_path("/usr/share/backgrounds/gnome/Tree.jpg").unwrap();
-//!     wallpaper::set_mode(wallpaper::Mode::Crop).unwrap();
-//!     println!("{:?}", wallpaper::get());
-//! }
+//!fn main() {
+//!    println!("{:?}", wallpaper::get());
+//!    wallpaper::set_from_path("/usr/share/backgrounds/gnome/adwaita-day.png").unwrap();
+//!    wallpaper::set_mode(wallpaper::Mode::Crop).unwrap();
+//!    println!("{:?}", wallpaper::get());
+//!}
 //! ```
 
 use std::error::Error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,22 @@ use std::error::Error;
 #[cfg(any(unix, windows))]
 extern crate dirs;
 
+#[cfg(feature = "from_url")]
+#[cfg(any(unix, windows))]
+extern crate reqwest;
+
+#[cfg(feature = "from_url")]
+#[cfg(any(unix, windows))]
+extern crate url;
+
+#[cfg(feature = "from_url")]
+#[cfg(any(unix, windows))]
+use std::fs::File;
+
+#[cfg(feature = "from_url")]
+#[cfg(any(unix, windows))]
+use url::Url;
+
 // unix
 #[cfg(unix)]
 extern crate enquote;
@@ -85,6 +101,23 @@ pub enum Mode {
     Span,
     Stretch,
     Tile,
+}
+
+#[cfg(feature = "from_url")]
+#[cfg(any(unix, windows))]
+fn download_image(url: &Url) -> Result<String> {
+    let cache_dir = dirs::cache_dir().ok_or("no cache dir")?;
+    let segments = url.path_segments().ok_or("no path segments")?;
+    let mut file_name = segments.last().ok_or("no file name")?;
+    if file_name.is_empty() {
+        file_name = "wallpaper";
+    }
+    let file_path = cache_dir.join(file_name);
+
+    let mut file = File::create(&file_path)?;
+    reqwest::blocking::get(url.as_str())?.copy_to(&mut file)?;
+
+    Ok(file_path.to_str().to_owned().unwrap().into())
 }
 
 #[cfg(unix)]

--- a/src/linux/kde.rs
+++ b/src/linux/kde.rs
@@ -1,6 +1,4 @@
 use crate::{run, Mode, Result};
-use dirs;
-use enquote;
 use std::fs::File;
 use std::io::BufRead;
 use std::io::BufReader;

--- a/src/linux/kde.rs
+++ b/src/linux/kde.rs
@@ -14,8 +14,8 @@ pub fn get() -> Result<String> {
     let reader = BufReader::new(file);
     for line in reader.lines() {
         let line = line?;
-        if line.starts_with("Image=") {
-            let mut uri = line[6..].trim();
+        if let Some(end) = line.strip_prefix("Image=") {
+            let mut uri = end.trim();
             if uri.starts_with("file://") {
                 uri = &uri[7..];
             }

--- a/src/linux/lxde.rs
+++ b/src/linux/lxde.rs
@@ -1,5 +1,4 @@
 use crate::{run, Mode, Result};
-use dirs;
 use ini::Ini;
 use std::env;
 

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -5,7 +5,7 @@ mod xfce;
 
 use crate::{run, Mode, Result};
 use enquote;
-use get_stdout;
+use crate::get_stdout;
 use std::{env, process::Command};
 
 #[cfg(feature = "from_url")]

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -3,9 +3,8 @@ mod kde;
 mod lxde;
 mod xfce;
 
-use crate::{run, Mode, Result};
-use enquote;
 use crate::get_stdout;
+use crate::{run, Mode, Result};
 use std::{env, process::Command};
 
 #[cfg(feature = "from_url")]

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -9,7 +9,7 @@ use crate::get_stdout;
 use std::{env, process::Command};
 
 #[cfg(feature = "from_url")]
-use download_image;
+use crate::download_image;
 
 /// Returns the wallpaper of the current desktop.
 pub fn get() -> Result<String> {

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -13,7 +13,7 @@ use download_image;
 
 /// Returns the wallpaper of the current desktop.
 pub fn get() -> Result<String> {
-    let desktop = env::var("XDG_CURRENT_DESKTOP").unwrap_or(Default::default());
+    let desktop = env::var("XDG_CURRENT_DESKTOP").unwrap_or_default();
 
     if gnome::is_compliant(&desktop) {
         return gnome::get();
@@ -44,7 +44,7 @@ pub fn get() -> Result<String> {
 
 /// Sets the wallpaper for the current desktop from a file path.
 pub fn set_from_path(path: &str) -> Result<()> {
-    let desktop = env::var("XDG_CURRENT_DESKTOP").unwrap_or(Default::default());
+    let desktop = env::var("XDG_CURRENT_DESKTOP").unwrap_or_default();
 
     if gnome::is_compliant(&desktop) {
         return gnome::set(path);
@@ -85,7 +85,7 @@ pub fn set_from_path(path: &str) -> Result<()> {
                 return Ok(());
             }
 
-            return run("feh", &["--bg-fill", path]);
+            run("feh", &["--bg-fill", path])
         }
     }
 }
@@ -115,7 +115,7 @@ pub fn set_from_url(url: &str) -> Result<()> {
 }
 
 pub fn set_mode(mode: Mode) -> Result<()> {
-    let desktop = env::var("XDG_CURRENT_DESKTOP").unwrap_or(Default::default());
+    let desktop = env::var("XDG_CURRENT_DESKTOP").unwrap_or_default();
 
     if gnome::is_compliant(&desktop) {
         return gnome::set_mode(mode);

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -113,6 +113,7 @@ pub fn set_from_url(url: &str) -> Result<()> {
     }
 }
 
+/// Sets the wallpaper style.
 pub fn set_mode(mode: Mode) -> Result<()> {
     let desktop = env::var("XDG_CURRENT_DESKTOP").unwrap_or_default();
 

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -1,11 +1,10 @@
-use enquote;
-use get_stdout;
-use run;
-use Mode;
-use Result;
+use crate::get_stdout;
+use crate::run;
+use crate::Mode;
+use crate::Result;
 
 #[cfg(feature = "from_url")]
-use download_image;
+use crate::download_image;
 
 /// Returns the current wallpaper.
 pub fn get() -> Result<String> {

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -1,8 +1,11 @@
 use enquote;
 use get_stdout;
 use run;
-use Result;
 use Mode;
+use Result;
+
+#[cfg(feature = "from_url")]
+use download_image;
 
 /// Returns the current wallpaper.
 pub fn get() -> Result<String> {
@@ -27,6 +30,13 @@ pub fn set_from_path(path: &str) -> Result<()> {
             ),
         ],
     )
+}
+
+#[cfg(feature = "from_url")]
+// Sets the wallpaper from a URL.
+pub fn set_from_url(url: &str) -> Result<()> {
+    let path = download_image(&url.parse()?)?;
+    set_from_path(&path)
 }
 
 /// No-op. Unable to change with AppleScript.

--- a/src/unsupported.rs
+++ b/src/unsupported.rs
@@ -8,6 +8,11 @@ pub fn set_from_path(_: &str) -> Result<()> {
     Err("unsupported operating system".into())
 }
 
+#[cfg(feature = "from_url")]
+pub fn set_from_url(_: &str) -> Result<()> {
+    Err("unsupported operating system".into())
+}
+
 pub fn set_mode(_: Mode) -> Result<()> {
     Err("unsupported operating system".into())
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -13,6 +13,9 @@ use winapi::um::winuser::SPI_SETDESKWALLPAPER;
 use winreg::enums::*;
 use winreg::RegKey;
 
+#[cfg(feature = "from_url")]
+use download_image;
+
 /// Returns the current wallpaper.
 pub fn get() -> Result<String> {
     unsafe {
@@ -57,6 +60,13 @@ pub fn set_from_path(path: &str) -> Result<()> {
             Err(io::Error::last_os_error().into())
         }
     }
+}
+
+/// Sets the wallpaper from a URL.
+#[cfg(feature = "from_url")]
+pub fn set_from_url(url: &str) -> Result<()> {
+    let path = download_image(&url.parse()?)?;
+    set_from_path(&path)
 }
 
 /// Sets the wallpaper style.

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -14,7 +14,7 @@ use winreg::enums::*;
 use winreg::RegKey;
 
 #[cfg(feature = "from_url")]
-use download_image;
+use crate::download_image;
 
 /// Returns the current wallpaper.
 pub fn get() -> Result<String> {
@@ -30,7 +30,7 @@ pub fn get() -> Result<String> {
         if successful {
             let path = String::from_utf16(&buffer)?
                 // removes trailing zeroes from buffer
-                .trim_right_matches('\x00')
+                .trim_end_matches('\x00')
                 .into();
             Ok(path)
         } else {


### PR DESCRIPTION
Since I considered the functionality useful I restored the possibility to set a background through a URL. Given the correct discussion #5, I thought of hiding this function behind a feature, making sure that the auxiliary dependencies are used only if requested by the user.
Both the functions `set_from_path` and `set_from_url` have been tested on Windows 10, macOS 11.4 and Sway 1.6.1

Also, I converted the code to Rust 2018 that allows for cleaner and clearer dependency management.