### PR TITLE
updated gnome set fn to support dark mode

### DIFF
--- a/src/linux/gnome.rs
+++ b/src/linux/gnome.rs
@@ -15,10 +15,22 @@ pub fn get() -> Result<String> {
 
 pub fn set(path: &str) -> Result<()> {
     let uri = enquote::enquote('"', &format!("file://{}", path));
-    run(
+    let res = run(
         "gsettings",
         &["set", "org.gnome.desktop.background", "picture-uri", &uri],
+    );
+    run(
+        "gsettings",
+        &[
+            "set",
+            "org.gnome.desktop.background",
+            "picture-uri-dark",
+            &uri,
+        ],
     )
+    // Ignore the result because in Gnome < 42 the cmd could fail since
+    // key "picture-uri-dark" does not exists
+    .or_else(|_| res)
 }
 
 pub fn set_mode(mode: Mode) -> Result<()> {


### PR DESCRIPTION

Gnome 42 introduces the dark mode and the possibility to set two different wallpapers for the light (default) mode and the dark one.
When the dark mode is enabled, Gnome uses the key `picture-uri-dark` to get the picture to use as wallpaper (instead of `picture-uri`).