### PR TITLE
Improve error handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,8 @@ license = "Unlicense"
 
 [dependencies]
 dirs = { version = "1", optional = true }
-reqwest = { version = "0.11", optional = true, features = ["blocking"]}
+thiserror = "1"
+reqwest = { version = "0.11", optional = true, features = ["blocking"] }
 
 [target.'cfg(unix)'.dependencies]
 enquote = "1"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,37 +1,34 @@
-use thiserror::Error;
 use std::{io, string::FromUtf8Error};
+use thiserror::Error;
 
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum Error {
-	#[error("I/O Error: {0}")]
-	IOError(#[from] io::Error),
+    #[error("I/O Error: {0}")]
+    IOError(#[from] io::Error),
 
-	#[error("Invalid UTF-8: {0}")]
-	InvalidUtf8(#[from] FromUtf8Error),
+    #[error("Invalid UTF-8: {0}")]
+    InvalidUtf8(#[from] FromUtf8Error),
 
-	#[error("Invalid INI: {0}")]
-	InvalidIni(#[from] ini::ini::Error),
+    #[error("Invalid INI: {0}")]
+    InvalidIni(#[from] ini::ini::Error),
 
-	#[error("Enquote error: {0}")]
-	Enquote(#[from] enquote::Error),
+    #[error("Enquote error: {0}")]
+    Enquote(#[from] enquote::Error),
 
-	#[error("{command} exited with status code {code}")]
-	CommandFailed {
-		command: String,
-		code: i32
-	},
+    #[error("{command} exited with status code {code}")]
+    CommandFailed { command: String, code: i32 },
 
-	#[error("Could not find config directory")]
-	NoConfigDir,
+    #[error("Could not find config directory")]
+    NoConfigDir,
 
-	#[error("No {0} image found")]
-	NoImage(&'static str),
+    #[error("No {0} image found")]
+    NoImage(&'static str),
 
-	#[cfg(all(unix, not(target_os = "macos")))]
-	#[error("{0}")]
-	XfceNoDesktops(#[from] crate::linux::xfce::NoDesktopsError),
+    #[cfg(all(unix, not(target_os = "macos")))]
+    #[error("{0}")]
+    XfceNoDesktops(#[from] crate::linux::xfce::NoDesktopsError),
 
-	#[error("Unsupported Desktop")]
-	UnsupportedDesktop
+    #[error("Unsupported Desktop")]
+    UnsupportedDesktop,
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,37 @@
+use thiserror::Error;
+use std::{io, string::FromUtf8Error};
+
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum Error {
+	#[error("I/O Error: {0}")]
+	IOError(#[from] io::Error),
+
+	#[error("Invalid UTF-8: {0}")]
+	InvalidUtf8(#[from] FromUtf8Error),
+
+	#[error("Invalid INI: {0}")]
+	InvalidIni(#[from] ini::ini::Error),
+
+	#[error("Enquote error: {0}")]
+	Enquote(#[from] enquote::Error),
+
+	#[error("{command} exited with status code {code}")]
+	CommandFailed {
+		command: String,
+		code: i32
+	},
+
+	#[error("Could not find config directory")]
+	NoConfigDir,
+
+	#[error("No {0} image found")]
+	NoImage(&'static str),
+
+	#[cfg(all(unix, not(target_os = "macos")))]
+	#[error("{0}")]
+	XfceNoDesktops(#[from] crate::linux::xfce::NoDesktopsError),
+
+	#[error("Unsupported Desktop")]
+	UnsupportedDesktop
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,15 +19,16 @@
 //! ```
 //! use wallpaper;
 //!
-//!fn main() {
-//!    println!("{:?}", wallpaper::get());
-//!    wallpaper::set_from_path("/usr/share/backgrounds/gnome/adwaita-day.png").unwrap();
-//!    wallpaper::set_mode(wallpaper::Mode::Crop).unwrap();
-//!    println!("{:?}", wallpaper::get());
-//!}
+//! fn main() {
+//!     println!("{:?}", wallpaper::get());
+//!     wallpaper::set_from_path("/usr/share/backgrounds/gnome/adwaita-day.png").unwrap();
+//!     wallpaper::set_mode(wallpaper::Mode::Crop).unwrap();
+//!     println!("{:?}", wallpaper::get());
+//! }
 //! ```
 
-use std::error::Error;
+mod error;
+pub use error::Error;
 
 #[cfg(all(unix, not(target_os = "macos")))]
 mod linux;
@@ -62,7 +63,7 @@ mod from_url;
 #[cfg(feature = "from_url")]
 pub(crate) use from_url::download_image;
 
-type Result<T> = std::result::Result<T, Box<dyn Error>>;
+type Result<T, E = Error> = std::result::Result<T, E>;
 
 #[derive(Clone, Debug)]
 pub enum Mode {
@@ -82,12 +83,7 @@ fn get_stdout(command: &str, args: &[&str]) -> Result<String> {
     if output.status.success() {
         Ok(String::from_utf8(output.stdout)?.trim().into())
     } else {
-        Err(format!(
-            "{} exited with status code {}",
-            command,
-            output.status.code().unwrap_or(-1),
-        )
-        .into())
+        Err(Error::CommandFailed { command: command.to_string(), code: output.status.code().unwrap_or(-1) })
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,10 @@ fn get_stdout(command: &str, args: &[&str]) -> Result<String> {
     if output.status.success() {
         Ok(String::from_utf8(output.stdout)?.trim().into())
     } else {
-        Err(Error::CommandFailed { command: command.to_string(), code: output.status.code().unwrap_or(-1) })
+        Err(Error::CommandFailed {
+            command: command.to_string(),
+            code: output.status.code().unwrap_or(-1),
+        })
     }
 }
 

--- a/src/linux/kde.rs
+++ b/src/linux/kde.rs
@@ -1,4 +1,4 @@
-use crate::{run, Mode, Result, Error};
+use crate::{run, Error, Mode, Result};
 use std::{
     fs::File,
     io::{BufRead, BufReader},

--- a/src/linux/kde.rs
+++ b/src/linux/kde.rs
@@ -1,4 +1,4 @@
-use crate::{run, Mode, Result};
+use crate::{run, Mode, Result, Error};
 use std::{
     fs::File,
     io::{BufRead, BufReader},
@@ -7,7 +7,7 @@ use std::{
 /// Returns the wallpaper of KDE.
 pub fn get() -> Result<String> {
     let path = dirs::config_dir()
-        .ok_or("could not find config directory")?
+        .ok_or(Error::NoConfigDir)?
         .join("plasma-org.kde.plasma.desktop-appletsrc");
     let file = File::open(path)?;
     let reader = BufReader::new(file);
@@ -22,7 +22,7 @@ pub fn get() -> Result<String> {
         }
     }
 
-    Err("no kde image found".into())
+    Err(Error::NoImage("KDE"))
 }
 
 /// Sets the wallpaper for KDE.

--- a/src/linux/lxde.rs
+++ b/src/linux/lxde.rs
@@ -1,4 +1,4 @@
-use crate::{run, Mode, Result};
+use crate::{run, Mode, Result, Error};
 use ini::Ini;
 use std::env;
 
@@ -6,14 +6,13 @@ pub fn get() -> Result<String> {
     // DESKTOP_SESSION in used on Raspbian
     let session = env::var("DESKTOP_SESSION").unwrap_or_else(|_| "LXDE".into());
     let path = dirs::config_dir()
-        .ok_or("could not find config directory")?
+        .ok_or(Error::NoConfigDir)?
         .join(format!("pcmanfm/{}/desktop-items-0.conf", session));
     let ini = Ini::load_from_file(path)?;
     Ok(ini
         .section(Some("*"))
-        .ok_or("no '*' section found")?
-        .get("wallpaper")
-        .ok_or("no lxde image found")?
+        .and_then(|ini| ini.get("wallpaper"))
+        .ok_or(Error::NoImage("LXDE"))?
         .clone())
 }
 

--- a/src/linux/lxde.rs
+++ b/src/linux/lxde.rs
@@ -1,4 +1,4 @@
-use crate::{run, Mode, Result, Error};
+use crate::{run, Error, Mode, Result};
 use ini::Ini;
 use std::env;
 

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -3,7 +3,7 @@ mod kde;
 mod lxde;
 pub(crate) mod xfce;
 
-use crate::{get_stdout, run, Mode, Result, Error};
+use crate::{get_stdout, run, Error, Mode, Result};
 use std::{env, process::Command};
 
 #[cfg(feature = "from_url")]

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -1,9 +1,9 @@
 mod gnome;
 mod kde;
 mod lxde;
-mod xfce;
+pub(crate) mod xfce;
 
-use crate::{get_stdout, run, Mode, Result};
+use crate::{get_stdout, run, Mode, Result, Error};
 use std::{env, process::Command};
 
 #[cfg(feature = "from_url")]
@@ -36,7 +36,7 @@ pub fn get() -> Result<String> {
                 "/com/deepin/wrap/gnome/desktop/background/picture-uri",
             ],
         ),
-        _ => Err("unsupported desktop".into()),
+        _ => Err(Error::UnsupportedDesktop),
     }
 }
 
@@ -131,7 +131,7 @@ pub fn set_mode(mode: Mode) -> Result<()> {
                 &mode.get_gnome_string(),
             ],
         ),
-        _ => Err("unsupported desktop".into()),
+        _ => Err(Error::UnsupportedDesktop),
     }
 }
 

--- a/src/linux/xfce.rs
+++ b/src/linux/xfce.rs
@@ -2,7 +2,7 @@ use crate::{get_stdout, run, Mode, Result};
 use std::error::Error;
 
 #[derive(Debug)]
-struct NoDesktopsError;
+pub struct NoDesktopsError;
 
 impl Error for NoDesktopsError {}
 
@@ -21,7 +21,7 @@ fn get_desktop_props(key: &str) -> Result<Vec<String>> {
         .collect::<Vec<String>>();
 
     if desktops.is_empty() {
-        return Err(Box::new(NoDesktopsError));
+        return Err(NoDesktopsError.into());
     }
 
     Ok(desktops)


### PR DESCRIPTION
`Box<dyn Error>` is bad practice: It does not allow for user code to check what the error condition is; and it is incompatible with other error handling libraries like `anyhow`. This PR adds an `Error` enum that fixes both these problems.