### PR TITLE
Canonicalize paths on windows

### DIFF
--- a/src/windows.rs
+++ b/src/windows.rs
@@ -42,11 +42,15 @@ pub fn get() -> Result<String> {
 /// Sets the wallpaper from a file.
 pub fn set_from_path(path: &str) -> Result<()> {
     unsafe {
-        let path = OsStr::new(path)
+        let path = std::fs::canonicalize(path)?;
+
+        let path = path
+            .as_os_str()
             .encode_wide()
             // append null byte
             .chain(iter::once(0))
             .collect::<Vec<u16>>();
+
         let successful = SystemParametersInfoW(
             SPI_SETDESKWALLPAPER,
             0,


### PR DESCRIPTION
The function `SystemParametersInfoW` doesn't error out if the provided path is relative or points to a file that does not exists, it just replaces the current wallpaper by a solid color. Fix it by trying the canonicalize the path before using it.

Depends on #18, otherwise this does not build.